### PR TITLE
Add Logging Hook

### DIFF
--- a/ChainHelper.php
+++ b/ChainHelper.php
@@ -5,12 +5,20 @@
 	class ChainHelper {
 		protected $_nodes = array();
 		protected $_isEvent = false;
+		protected $_doDebug = false;
+		protected $_logger = null;
 
 
-		public function __construct($isEvent = false) {
+		public function __construct($isEvent = false, $doDebug = false) {
 			$this->_isEvent = $isEvent;
 
 			return;
+		}
+
+		public function toggleDebug($doDebug) {
+			$this->_doDebug = ($doDebug) ? true : false;
+
+			return $this;
 		}
 
 		public function getNodeList() {
@@ -26,18 +34,40 @@
 			return $ret;
 		}
 
+		public function hookLogger($callback) {
+			if ($callback === null || !is_callable($callback)) {
+				return false;
+			}
+
+			$this->_logger = $callback;
+
+			return true;
+		}
+
 		public function isEvent() {
 			return $this->_isEvent;
 		}
 
 		public function linkNode(NodeBase $node) {
 			if (!$node->isValid()) {
+				if ($this->_doDebug) {
+					$this->log("Attempted to add invalid node: " . $node);
+				}
+
 				return $this;
 			}
 
 			if ($this->_isEvent) {
+				if ($this->_doDebug) {
+					$this->log("Setting event node: " . $node);
+				}
+
 				$this->_nodes = array($node);
 			} else {
+				if ($this->_doDebug) {
+					$this->log("Linking new node: " . $node);
+				}
+
 				$this->_nodes[] = $node;
 			}
 
@@ -46,14 +76,26 @@
 
 		public function traverse(DispatchBase &$dispatch, $sender = null) {
 			if (count($this->_nodes) < 1) {
+				if ($this->_doDebug) {
+					$this->log("Attempted to traverse chain with no nodes");
+				}
+
 				return false;
 			}
 
 			if (!$dispatch->isValid()) {
+				if ($this->_doDebug) {
+					$this->log("Attempted to traverse chain with invalid dispatch: " . $dispatch);
+				}
+
 				return false;
 			}
 
 			if ($dispatch->isConsumable() && $dispatch->isConsumed()) {
+				if ($this->_doDebug) {
+					$this->log("Attempted to traverse chain with consumed dispatch: " . $dispatch);
+				}
+
 				return false;
 			}
 
@@ -64,19 +106,39 @@
 			$isConsumable = $dispatch->isConsumable();
 
 			if ($this->_isEvent) {
+				if ($this->_doDebug) {
+					$this->log("Sending dispatch (" . $dispatch . ") to event node: " . $this->_nodes[0]);
+				}
+
 				$this->_nodes[0]->process($sender, $dispatch);
 			} else {
 				$len = count($this->_nodes);
 
 				for ($i = 0; $i < $len; ++$i) {
+					if ($this->_doDebug) {
+						$this->log("Sending dispatch (" . $dispatch . ") to node: " . $this->_nodes[$i]);
+					}
+
 					$this->_nodes[$i]->process($sender, $dispatch);
 
 					if ($isConsumable && $dispatch->isConsumed()) {
+						if ($this->_doDebug) {
+							$this->log("Dispatch (" . $dispatch . ") consumed by node: " . $this->_nodes[$i]);
+						}
+
 						break;
 					}
 				}
 			}
 
 			return true;
+		}
+
+		protected function log($message) {
+			if ($this->_logger !== null) {
+				$this->_logger($message);
+			}
+
+			return;
 		}
 	}

--- a/ChainHelper.php
+++ b/ChainHelper.php
@@ -11,6 +11,7 @@
 
 		public function __construct($isEvent = false, $doDebug = false) {
 			$this->_isEvent = $isEvent;
+			$this->_doDebug = $doDebug;
 
 			return;
 		}

--- a/ChainHelper.php
+++ b/ChainHelper.php
@@ -35,11 +35,7 @@
 			return $ret;
 		}
 
-		public function hookLogger($callback) {
-			if ($callback === null || !is_callable($callback)) {
-				return false;
-			}
-
+		public function hookLogger(callable $callback) {
 			$this->_logger = $callback;
 
 			return true;
@@ -137,7 +133,7 @@
 
 		protected function log($message) {
 			if ($this->_logger !== null) {
-				$this->_logger($message);
+				call_user_func($this->_logger, $message);
 			}
 
 			return;

--- a/ChainHelper.php
+++ b/ChainHelper.php
@@ -11,7 +11,7 @@
 
 		public function __construct($isEvent = false, $doDebug = false) {
 			$this->_isEvent = $isEvent;
-			$this->_doDebug = $doDebug;
+			$this->toggleDebug($doDebug);
 
 			return;
 		}

--- a/DispatchBase.php
+++ b/DispatchBase.php
@@ -12,7 +12,7 @@
 
 
 		public function __toString() {
-			return static::class . "{ \"calledDateTime\": \"{$this->_calledDateTime}\", " .
+			return static::class . "{ \"calledDateTime\": \"" . $this->_calledDateTime->format("Y-m-d G:i:s") . "\", " .
 				"\"isConsumable\": \"{$this->_isConsumable}\", " .
 				"\"isStateful\": \"{$this->_isStateful}\", " .
 				"\"isConsumed\": \"{$this->_isConsumed}\" }";

--- a/DispatchBase.php
+++ b/DispatchBase.php
@@ -11,6 +11,13 @@
 		private $_calledDateTime;
 
 
+		public function __toString() {
+			return static::class . "{ \"calledDateTime\": \"{$this->_calledDateTime}\", " .
+				"\"isConsumable\": \"{$this->_isConsumable}\", " .
+				"\"isStateful\": \"{$this->_isStateful}\", " .
+				"\"isConsumed\": \"{$this->_isConsumed}\" }";
+		}
+		
 		public function consume() {
 			if ($this->_isConsumable && !$this->_isConsumed) {
 				$this->_isConsumed = true;

--- a/NodeBase.php
+++ b/NodeBase.php
@@ -7,6 +7,10 @@
 		protected $_version = null;
 
 
+		public function __toString() {
+			return static::class . "{ \"key\": \"{$this->_key}\", \"version\": \"{$this->_version}\" }";
+		}
+
 		public function getKey() {
 			return $this->_key;
 		}

--- a/Tests/LoggingTest.php
+++ b/Tests/LoggingTest.php
@@ -1,0 +1,108 @@
+<?php
+
+	namespace Stoic\Chain\Tests;
+
+	use PHPUnit\Framework\TestCase;
+	use Stoic\Chain\ChainHelper;
+	use Stoic\Chain\DispatchBase;
+	use Stoic\Chain\NodeBase;
+
+	class LogCache {
+		public $_messages = array();
+
+		public function receiveLog($message) {
+			$this->_messages[] = $message;
+		}
+	}
+
+	class TestDispatch extends DispatchBase {
+		public function initialize($input) {
+			$this->makeValid();
+
+			return;
+		}
+	}
+
+	class TestConsumableDispatch extends DispatchBase {
+		public function initialize($input) {
+			$this->makeConsumable();
+			$this->makeValid();
+
+			return;
+		}
+	}
+
+	class NonConsumeTestNode extends NodeBase {
+		public function __construct() {
+			$this->setKey("NonConsumeTestNode")->setVersion("1.0.0");
+
+			return;
+		}
+
+		public function process($sender, DispatchBase &$dispatch) {
+			return;
+		}
+	}
+
+	class ConsumeTestNode extends NodeBase {
+		public function __construct() {
+			$this->setKey("ConsumeTestNode")->setVersion("1.0.0");
+
+			return;
+		}
+
+		public function process($sender, DispatchBase &$dispatch) {
+			$dispatch->consume();
+
+			return;
+		}
+	}
+
+	class LoggingTest extends TestCase {
+		public function test_logMessageCount() {
+			$lg_nonevent = new LogCache();
+			$lg_event = new LogCache();
+			$lg_norm = new LogCache();
+			$lg_consume = new LogCache();
+			
+			$ch_nonevent = new ChainHelper(false, true);
+			$ch_event = new ChainHelper(true, true);
+			$ch_norm = new ChainHelper();
+			$ch_consume = new ChainHelper(false, true);
+
+			$this->assertTrue($ch_nonevent->hookLogger(array($lg_nonevent, "receiveLog")));
+			$this->assertTrue($ch_event->hookLogger(array($lg_event, "receiveLog")));
+			$this->assertTrue($ch_norm->hookLogger(array($lg_norm, "receiveLog")));
+			$this->assertTrue($ch_consume->hookLogger(array($lg_consume, "receiveLog")));
+
+			$ch_nonevent->linkNode(new NonConsumeTestNode());
+			$ch_nonevent->linkNode(new ConsumeTestNode());
+
+			$ch_event->linkNode(new NonConsumeTestNode());
+			$ch_event->linkNode(new ConsumeTestNode());
+
+			$ch_norm->linkNode(new NonConsumeTestNode());
+			$ch_norm->linkNode(new ConsumeTestNode());
+
+			$ch_consume->linkNode(new ConsumeTestNode());
+			$ch_consume->linkNode(new NonConsumeTestNode());
+
+			$disp = new TestDispatch();
+			$disp->initialize([]);
+
+			$cdisp = new TestConsumableDispatch();
+			$cdisp->initialize([]);
+
+			$ch_nonevent->traverse($disp);
+			$ch_event->traverse($disp);
+			$ch_norm->traverse($disp);
+			$ch_consume->traverse($cdisp);
+
+			$this->assertEquals(4, count($lg_nonevent->_messages));
+			$this->assertEquals(3, count($lg_event->_messages));
+			$this->assertEquals(0, count($lg_norm->_messages));
+			$this->assertEquals(4, count($lg_consume->_messages));
+
+			return;
+		}
+	}

--- a/stoic-php-chain.phpproj
+++ b/stoic-php-chain.phpproj
@@ -21,6 +21,7 @@
     <Compile Include="NodeBase.php" />
     <Compile Include="ChainHelper.php" />
     <Compile Include="Tests\ChainTest.php" />
+    <Compile Include="Tests\LoggingTest.php" />
     <Compile Include="Tests\ValidityTest.php" />
   </ItemGroup>
   <ItemGroup>

--- a/stoic-php-chain.phpproj
+++ b/stoic-php-chain.phpproj
@@ -20,8 +20,15 @@
     <Compile Include="DispatchBase.php" />
     <Compile Include="NodeBase.php" />
     <Compile Include="ChainHelper.php" />
+    <Compile Include="Tests\ChainTest.php" />
+    <Compile Include="Tests\ValidityTest.php" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include=".travis.yml" />
     <Content Include="composer.json" />
+    <Content Include="phpunit.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Tests\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adding a `hookLogger()` method to the `ChainHelper` class which allows a simple message to be passed onto an external logging interface as a way to aid with debugging chains.  Also includes addition of `__toString()` magic methods to `DispatchBase` and `NodeBase` abstract classes.